### PR TITLE
Add a retrying background batch producer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
 before_script:
   - kinesalite --createStreamMs 5 --deleteStreamMs 5 &
 
-script: go test
+script: go test -parallel 2
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ You can find a tool for interacting with kinesis from the command line in folder
 
 ## Testing
 
+### Local Kinesis Server
+
 The tests require a local Kinesis server such as [Kinesalite](https://github.com/mhart/kinesalite)
 to be running and reachable at `http://127.0.0.1:4567`.
 
@@ -24,3 +26,8 @@ deletion faster than the default of 500ms, like so:
     kinesalite --createStreamMs 5 --deleteStreamMs 5 &
 
 The `&` runs Kinesalite in the background, which is probably what you want.
+
+### go test
+
+Some of the tests are marked as safe to be run in parallel, so to speed up test execution you might
+want to run `go test` with [the `-parallel n` flag](https://golang.org/cmd/go/#hdr-Description_of_testing_flags).

--- a/batchproducer/batchproducer.go
+++ b/batchproducer/batchproducer.go
@@ -42,13 +42,13 @@ type Producer interface {
 type StatReceiver interface {
 	// Receive will be called by the main Producer goroutine so it will block all batches from being
 	// sent, so make sure it is either very fast or never blocks at all!
-	Receive(StatsFrame)
+	Receive(StatsBatch)
 }
 
-// StatsFrame is a kind of a snapshot of activity and happenings. Some of its fields represent
-// "moment-in-time" values e.g. BufferSize is the size of the buffer at the moment the StatsFrame
-// is sent. Other fields are cumulative since the last StatsFrame, i.e. ErrorsSinceLastStat.
-type StatsFrame struct {
+// StatsBatch is a kind of a snapshot of activity and happenings. Some of its fields represent
+// "moment-in-time" values e.g. BufferSize is the size of the buffer at the moment the StatsBatch
+// is sent. Other fields are cumulative since the last StatsBatch, i.e. ErrorsSinceLastStat.
+type StatsBatch struct {
 	// Moment-in-time stats
 	BufferSize int
 
@@ -101,7 +101,7 @@ func New(
 		maxAttemptsPerRecord: 10,
 		logger:               logger,
 		statInterval:         time.Second,
-		currentStat:          new(StatsFrame),
+		currentStat:          new(StatsBatch),
 		records:              make(chan batchRecord, bufferSize),
 		stop:                 make(chan interface{}),
 	}
@@ -122,7 +122,7 @@ type batchProducer struct {
 	currentDelay         time.Duration
 	statInterval         time.Duration
 	statReceiver         StatReceiver
-	currentStat          *StatsFrame
+	currentStat          *StatsBatch
 	records              chan batchRecord
 	stop                 chan interface{}
 }
@@ -336,5 +336,5 @@ func (b *batchProducer) sendStats() {
 	// the provider of the BatchStatReceiver must ensure that it is either very fast or non-blocking.
 	b.statReceiver.Receive(*b.currentStat)
 
-	b.currentStat = new(StatsFrame)
+	b.currentStat = new(StatsBatch)
 }

--- a/batchproducer/batchproducer.go
+++ b/batchproducer/batchproducer.go
@@ -171,9 +171,6 @@ func (b *batchProducer) run() {
 	}
 
 	b.setRunning(true)
-	// Very important to defer the call to b.setRunning(false) — not just so it’s accurate
-	// after b.Stop has been called but also just in case this main goroutine dies in the
-	// background — for example because of a panic.
 	defer b.setRunning(false)
 
 	for {

--- a/batchproducer/batchproducer.go
+++ b/batchproducer/batchproducer.go
@@ -63,14 +63,17 @@ type BatchingKinesisClient interface {
 	PutRecords(args *kinesis.RequestArgs) (resp *kinesis.PutRecordsResp, err error)
 }
 
-// NewBatchProducer creates and returns a BatchProducer.
-// The BatchProducer that is returned will flush a batch to Kinesis whenever either
+// New creates and returns a BatchProducer that will do nothing until its Start method is called.
+// Once it is started, it will flush a batch to Kinesis whenever either
 // the flushInterval occurs (if flushInterval > 0) or the batchSize is reached,
-// whichever happens first. If the number of records in the buffer is equal to
-// or greater than bufferSize then the Add method will block.
+// whichever happens first.
+// `bufferSize` is the size of the buffer that stores records before they are sent to the Kinesis
+// stream. If the number of records in the buffer is equal to or greater than bufferSize then the
+// Add method will block.
+// `batchSize` is the max number of records in each batch request sent to Kinesis.
 // TODO: this is too many args. Maybe instead have some defaults and add some setter methods for the less critical
 // params
-func NewBatchProducer(
+func New(
 	client BatchingKinesisClient,
 	streamName string,
 	bufferSize int,

--- a/batchproducer/batchproducer.go
+++ b/batchproducer/batchproducer.go
@@ -241,6 +241,7 @@ func (b *batchProducer) sendBatch() {
 		return
 	}
 
+	// In the future, maybe this could be a RetryPolicy or something
 	if b.consecutiveErrors == 1 {
 		b.currentDelay = 50 * time.Millisecond
 	} else if b.consecutiveErrors > 1 {
@@ -330,9 +331,6 @@ func (b *batchProducer) returnSomeFailedRecordsToBuffer(res *kinesis.PutRecordsR
 
 func (b *batchProducer) sendStats() {
 	b.currentStat.BufferSize = len(b.records)
-
-	// TEMP TMEP TEMP
-	// fmt.Printf("Sending stat: %+v\n", b.currentStat)
 
 	// I considered running this as a goroutine, but I’m concerned about leaks. So instead, for now,
 	// the provider of the BatchStatReceiver must ensure that it is either very fast or non-blocking.

--- a/batchproducer/batchproducer.go
+++ b/batchproducer/batchproducer.go
@@ -1,0 +1,314 @@
+package batchproducer
+
+import (
+	"errors"
+	"log"
+	"time"
+
+	"github.com/timehop/go-kinesis"
+)
+
+// BatchProducer collects records individually and then sends them to Kinesis in
+// batches in the background using PutRecords, with retries.
+// A BatchProducer will do nothing until Start is called.
+type BatchProducer interface {
+	// Start starts the main goroutine. No need to call it using `go`.
+	Start() error
+	Stop() error
+
+	// Add might block if the BatchProducer has a buffer and the buffer is full.
+	// In order to prevent filling the buffer and eventually blocking indefinitely,
+	// Add will fail and return an error if the BatchProducer is not started.
+	Add(data []byte, partitionKey string) error
+
+	// Setters
+	SetMaxAttemptsPerRecord(int) error
+	SetStatReceiver(BatchStatReceiver) error
+
+	// This interval will be used to make a *best effort* attempt to send stats *approximately*
+	// when this interval elapses. There’s no guarantee, however, since the main goroutine is
+	// used to send the stats and therefore there may be some skew.
+	SetStatInterval(time.Duration) error
+}
+
+// BatchStatReceiver defines an object that can accept stats.
+type BatchStatReceiver interface {
+	// Receive will be called by the main BatchProducer goroutine so it will block all batches from being
+	// sent, so make sure it is either very fast or never blocks at all!
+	Receive(BatchStat)
+}
+
+// BatchStat is a kind of a snapshot of activity and happenings. Some of its fields represent
+// "moment-in-time" values e.g. BufferSize is the size of the buffer at the moment the Stat is
+// sent. Other fields are cumulative since the last Stat, i.e. ErrorsSinceLastStat.
+type BatchStat struct {
+	// Moment-in-time stats
+	BufferSize int
+
+	// Cumulative stats
+	KinesisErrorsSinceLastStat           int
+	RecordsSentSuccessfullySinceLastStat int
+	RecordsDroppedSinceLastStat          int
+}
+
+// BatchingKinesisClient is a subset of KinesisClient to ease mocking.
+type BatchingKinesisClient interface {
+	PutRecords(args *kinesis.RequestArgs) (resp *kinesis.PutRecordsResp, err error)
+}
+
+// NewBatchProducer creates and returns a BatchProducer.
+// The BatchProducer that is returned will flush a batch to Kinesis whenever either
+// the flushInterval occurs (if flushInterval > 0) or the batchSize is reached,
+// whichever happens first. If the number of records in the buffer is equal to
+// or greater than bufferSize then the Add method will block.
+// TODO: this is too many args. Maybe instead have some defaults and add some setter methods for the less critical
+// params
+func NewBatchProducer(
+	client BatchingKinesisClient,
+	streamName string,
+	bufferSize int,
+	flushInterval time.Duration,
+	batchSize int,
+	logger *log.Logger,
+) (BatchProducer, error) {
+	if batchSize < 1 || batchSize > 500 {
+		return nil, errors.New("batchSize must be between 1 and 500 inclusive")
+	}
+
+	if bufferSize < batchSize && flushInterval <= 0 {
+		return nil, errors.New("If bufferSize < batchSize && flushInterval <= 0 then the buffer will eventually fill up and Add will block forever.")
+	}
+
+	if flushInterval > 0 && flushInterval < 50*time.Millisecond {
+		return nil, errors.New("Are you crazy?")
+	}
+
+	batchProducer := batchProducer{
+		client:               client,
+		streamName:           streamName,
+		flushInterval:        flushInterval,
+		batchSize:            batchSize,
+		maxAttemptsPerRecord: 10,
+		logger:               logger,
+		statInterval:         time.Second,
+		currentStat:          new(BatchStat),
+		records:              make(chan batchRecord, bufferSize),
+		stop:                 make(chan interface{}),
+	}
+
+	return &batchProducer, nil
+}
+
+type batchProducer struct {
+	client               BatchingKinesisClient
+	streamName           string
+	flushInterval        time.Duration
+	batchSize            int
+	maxAttemptsPerRecord int
+	logger               *log.Logger
+	running              bool
+	consecutiveErrors    int
+	currentDelay         time.Duration
+	statInterval         time.Duration
+	statReceiver         BatchStatReceiver
+	currentStat          *BatchStat
+	records              chan batchRecord
+	stop                 chan interface{}
+}
+
+type batchRecord struct {
+	data         []byte
+	partitionKey string
+	sendAttempts int
+}
+
+// from/for interface BatchProducer
+func (b *batchProducer) Add(data []byte, partitionKey string) error {
+	if !b.running {
+		return errors.New("Cannot call Add when BatchProducer is not running (to prevent the buffer filling up and Add blocking indefinitely).")
+	}
+	b.records <- batchRecord{data: data, partitionKey: partitionKey}
+	return nil
+}
+
+// from/for interface BatchProducer
+func (b *batchProducer) Start() error {
+	if b.running {
+		return nil
+	}
+
+	go b.run()
+
+	for !b.running {
+		// Give the goroutine a chance to start before returning.
+		time.Sleep(1 * time.Microsecond)
+	}
+
+	return nil
+}
+
+func (b *batchProducer) run() {
+	flushTick := time.Tick(b.flushInterval)
+
+	var statTick <-chan time.Time
+	if b.statReceiver != nil {
+		statTick = time.Tick(b.statInterval)
+	}
+
+	b.running = true
+	defer func() { b.running = false }()
+
+	for {
+		select {
+		case <-flushTick:
+			b.sendBatch()
+		case <-statTick:
+			b.sendStats()
+		case <-b.stop:
+			break
+		default:
+			if len(b.records) >= b.batchSize {
+				b.sendBatch()
+			} else {
+				time.Sleep(1 * time.Millisecond)
+			}
+		}
+	}
+}
+
+// from/for interface BatchProducer
+func (b *batchProducer) Stop() error {
+	if b.running {
+		b.stop <- true
+	}
+	return nil
+}
+
+func (b *batchProducer) SetMaxAttemptsPerRecord(v int) error {
+	if b.running {
+		return errors.New("Cannot set max attempts per record while BatchProducer is running.")
+	}
+	b.maxAttemptsPerRecord = v
+	return nil
+}
+
+func (b *batchProducer) SetStatReceiver(sr BatchStatReceiver) error {
+	if b.running {
+		return errors.New("Cannot set BatchStatReceiver while BatchProducer is running.")
+	}
+	b.statReceiver = sr
+	return nil
+}
+
+func (b *batchProducer) SetStatInterval(si time.Duration) error {
+	if b.running {
+		return errors.New("Cannot set stat interval while BatchProducer is running.")
+	}
+	b.statInterval = si
+	return nil
+}
+
+func (b *batchProducer) sendBatch() {
+	if len(b.records) == 0 {
+		return
+	}
+
+	if b.consecutiveErrors == 1 {
+		b.currentDelay = 50 * time.Millisecond
+	} else if b.consecutiveErrors > 1 {
+		b.currentDelay *= 2
+	}
+
+	if b.currentDelay > 0 {
+		b.logger.Printf("Delaying the batch by %v because of %v consecutive errors", b.currentDelay, b.consecutiveErrors)
+		time.Sleep(b.currentDelay)
+	}
+
+	records := b.takeRecordsFromBuffer()
+	res, err := b.client.PutRecords(b.recordsToArgs(records))
+
+	if err != nil {
+		b.consecutiveErrors++
+		b.currentStat.KinesisErrorsSinceLastStat++
+		b.logger.Printf("Error occurred when sending PutRecords request to Kinesis stream %v: %v", b.streamName, err)
+		b.returnRecordsToBuffer(records)
+	} else {
+		b.consecutiveErrors = 0
+		b.currentDelay = 0
+		succeeded := len(records) - res.FailedRecordCount
+
+		b.currentStat.RecordsSentSuccessfullySinceLastStat += succeeded
+
+		if res.FailedRecordCount > 0 {
+			b.logger.Printf("Partial success when sending a PutRecords request to Kinesis stream %v: %v succeeded, %v failed. Re-enqueueing failed records.", b.streamName, succeeded, res.FailedRecordCount)
+			b.returnSomeFailedRecordsToBuffer(res, records)
+		}
+	}
+}
+
+func (b *batchProducer) takeRecordsFromBuffer() []batchRecord {
+	var size int
+	bufferLen := len(b.records)
+	if bufferLen >= b.batchSize {
+		size = b.batchSize
+	} else {
+		size = bufferLen
+	}
+
+	result := make([]batchRecord, size)
+	for i := 0; i < size; i++ {
+		result[i] = <-b.records
+	}
+	return result
+}
+
+func (b *batchProducer) recordsToArgs(records []batchRecord) *kinesis.RequestArgs {
+	args := kinesis.NewArgs()
+	args.Add("StreamName", b.streamName)
+	for _, record := range records {
+		args.AddRecord(record.data, record.partitionKey)
+	}
+	return args
+}
+
+// TODO: perhaps we should use a deque internally as the buffer so we can return records to
+// the front of the queue.
+func (b *batchProducer) returnRecordsToBuffer(records []batchRecord) {
+	for _, record := range records {
+		// Not using b.Add because we want to preserve the value of record.sendAttempts.
+		b.records <- record
+	}
+}
+
+func (b *batchProducer) returnSomeFailedRecordsToBuffer(res *kinesis.PutRecordsResp, records []batchRecord) {
+	for i, result := range res.Records {
+		record := records[i]
+		if result.ErrorCode != "" {
+			record.sendAttempts++
+
+			if record.sendAttempts < b.maxAttemptsPerRecord {
+				b.logger.Printf("Re-enqueueing failed record to buffer for retry. Error code was: '%v' and message was '%v'", result.ErrorCode, result.ErrorMessage)
+				// Not using b.Add because we want to preserve the value of record.sendAttempts.
+				b.records <- record
+			} else {
+				b.currentStat.RecordsDroppedSinceLastStat++
+				msg := "NOT re-enqueueing failed record for retry, as it has hit %v attempts, " +
+					"which is the maximum. Error code was: '%v' and message was '%v'"
+				b.logger.Printf(msg, record.sendAttempts, result.ErrorCode, result.ErrorMessage)
+			}
+		}
+	}
+}
+
+func (b *batchProducer) sendStats() {
+	b.currentStat.BufferSize = len(b.records)
+
+	// TEMP TMEP TEMP
+	// fmt.Printf("Sending stat: %+v\n", b.currentStat)
+
+	// I considered running this as a goroutine, but I’m concerned about leaks. So instead, for now,
+	// the provider of the BatchStatReceiver must ensure that it is either very fast or non-blocking.
+	b.statReceiver.Receive(*b.currentStat)
+
+	b.currentStat = new(BatchStat)
+}

--- a/batchproducer/batchproducer_test.go
+++ b/batchproducer/batchproducer_test.go
@@ -455,7 +455,7 @@ func newProducer(client *mockBatchingClient, bufferSize int, flushInterval time.
 		batchSize:            batchSize,
 		maxAttemptsPerRecord: 2,
 		logger:               discardLogger,
-		currentStat:          new(BatchStat),
+		currentStat:          new(StatsFrame),
 		records:              make(chan batchRecord, bufferSize),
 		stop:                 make(chan interface{}),
 	}
@@ -484,15 +484,15 @@ func (b *batchProducer) addRecordsAndWait(numRecords int, millisToWait int) {
 }
 
 type statReceiver struct {
-	stats                            []BatchStat
+	stats                            []StatsFrame
 	totalKinesisErrorsSinceLastStat  int
 	totalRecordsSentSuccessfully     int
 	totalRecordsDroppedSinceLastStat int
 }
 
-func (s *statReceiver) Receive(bs BatchStat) {
-	s.stats = append(s.stats, bs)
-	s.totalKinesisErrorsSinceLastStat += bs.KinesisErrorsSinceLastStat
-	s.totalRecordsSentSuccessfully += bs.RecordsSentSuccessfullySinceLastStat
-	s.totalRecordsDroppedSinceLastStat += bs.RecordsDroppedSinceLastStat
+func (s *statReceiver) Receive(sf StatsFrame) {
+	s.stats = append(s.stats, sf)
+	s.totalKinesisErrorsSinceLastStat += sf.KinesisErrorsSinceLastStat
+	s.totalRecordsSentSuccessfully += sf.RecordsSentSuccessfullySinceLastStat
+	s.totalRecordsDroppedSinceLastStat += sf.RecordsDroppedSinceLastStat
 }

--- a/batchproducer/batchproducer_test.go
+++ b/batchproducer/batchproducer_test.go
@@ -1,0 +1,498 @@
+package batchproducer
+
+import (
+	"errors"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/timehop/go-kinesis"
+)
+
+var (
+	discardLogger = log.New(ioutil.Discard, "", 0)
+	stdoutLogger  = log.New(os.Stdout, "", 0)
+)
+
+func TestNewBatchProducerWithGoodValues(t *testing.T) {
+	t.Parallel()
+	b, err := NewBatchProducer(&mockBatchingClient{}, "foo", 10, 0, 10, discardLogger)
+	if b == nil {
+		t.Error("b == nil")
+	}
+	if err != nil {
+		t.Errorf("%q != nil", err)
+	}
+}
+
+func TestNewBatchProducerWithBadBatchSize(t *testing.T) {
+	t.Parallel()
+	b, err := NewBatchProducer(&mockBatchingClient{}, "foo", 10000, 0, 1000, discardLogger)
+	if b != nil {
+		t.Errorf("%q != nil", b)
+	}
+	if err == nil {
+		t.Error("err == nil")
+	}
+	if !strings.Contains(err.Error(), "between 1 and 500") {
+		t.Errorf("%q does not contain 'between 1 and 500'", err)
+	}
+}
+
+func TestNewBatchProducerWithBadValues(t *testing.T) {
+	t.Parallel()
+	b, err := NewBatchProducer(&mockBatchingClient{}, "foo", 10, 0, 500, discardLogger)
+	if b != nil {
+		t.Errorf("%q != nil", b)
+	}
+	if err == nil {
+		t.Fatalf("err == nil")
+	}
+	if !strings.Contains(err.Error(), "Add will block forever") {
+		t.Errorf("%q does not contain 'Add will block forever'", err)
+	}
+}
+
+func TestAddRecordWhenStarted(t *testing.T) {
+	t.Parallel()
+	b, err := NewBatchProducer(&mockBatchingClient{}, "foo", 100, 0, 10, discardLogger)
+	if err != nil {
+		t.Fatalf("%v != nil", err)
+	}
+
+	b.Start()
+	defer b.Stop()
+
+	err = b.Add([]byte("foo"), "bar")
+	if err != nil {
+		t.Errorf("%v != nil", err)
+	}
+}
+
+func TestAddRecordWhenStopped(t *testing.T) {
+	t.Parallel()
+	b, err := NewBatchProducer(&mockBatchingClient{}, "foo", 100, 0, 10, discardLogger)
+	if err != nil {
+		t.Fatalf("%v != nil", err)
+	}
+
+	err = b.Add([]byte("foo"), "bar")
+	if err == nil {
+		t.Errorf("%v == nil", err)
+	}
+}
+
+func TestFlushInterval(t *testing.T) {
+	t.Parallel()
+	c := &mockBatchingClient{}
+	b := newBatchProducer(c, 100, 2*time.Millisecond, 10)
+	b.Start()
+	defer b.Stop()
+
+	b.addRecordsAndWait(10, 0)
+	if len(b.records) != 10 {
+		t.Errorf("%v != 10", len(b.records))
+	}
+	if c.calls != 0 {
+		t.Errorf("%v != 0", c.calls)
+	}
+
+	time.Sleep(3 * time.Millisecond)
+	if len(b.records) != 0 {
+		t.Errorf("%v != 0", len(b.records))
+	}
+	if c.calls != 1 {
+		t.Errorf("%v != 1", c.calls)
+	}
+
+	// 20 more records should result in two more batches being sent
+	b.addRecordsAndWait(20, 8)
+	if len(b.records) != 0 {
+		t.Errorf("%v != 0", len(b.records))
+	}
+	if c.calls != 3 {
+		t.Errorf("%v != 3", c.calls)
+	}
+}
+
+func TestBatchSize(t *testing.T) {
+	t.Parallel()
+	c := &mockBatchingClient{}
+	b := newBatchProducer(c, 100, 0, 5)
+	b.Start()
+	defer b.Stop()
+
+	b.addRecordsAndWait(4, 2)
+	if len(b.records) != 4 {
+		t.Errorf("%v != 4", len(b.records))
+	}
+	if c.calls != 0 {
+		t.Errorf("%v != 0", c.calls)
+	}
+
+	b.addRecordsAndWait(1, 2)
+	if len(b.records) != 0 {
+		t.Errorf("%v != 0", len(b.records))
+	}
+	if c.calls != 1 {
+		t.Errorf("%v != 1", c.calls)
+	}
+
+	b.addRecordsAndWait(6, 2)
+	if len(b.records) != 1 {
+		t.Errorf("%v != 1", len(b.records))
+	}
+	if c.calls != 2 {
+		t.Errorf("%v != 2", c.calls)
+	}
+
+	b.addRecordsAndWait(19, 2)
+	if len(b.records) != 0 {
+		t.Errorf("%v != 0", len(b.records))
+	}
+	if c.calls != 6 {
+		t.Errorf("%v != 6", c.calls)
+	}
+}
+
+func TestBatchError(t *testing.T) {
+	t.Parallel()
+	c := &mockBatchingClient{shouldErr: true}
+	b := newBatchProducer(c, 100, 0, 5)
+	b.Start()
+	defer b.Stop()
+
+	b.addRecordsAndWait(5, 1)
+	if b.consecutiveErrors != 1 {
+		t.Errorf("%v != 1", b.consecutiveErrors)
+	}
+	if len(b.records) != 5 {
+		t.Errorf("%v != 5", len(b.records))
+	}
+
+	// Wait another 55 ms and another error should have occurred
+	time.Sleep(55 * time.Millisecond)
+	if b.consecutiveErrors != 2 {
+		t.Errorf("%v != 2", b.consecutiveErrors)
+	}
+	if len(b.records) != 5 {
+		t.Errorf("%v != 5", len(b.records))
+	}
+
+	b.Stop()
+	b.client = &mockBatchingClient{shouldErr: false}
+	b.Start()
+
+	time.Sleep(205 * time.Millisecond)
+	if b.consecutiveErrors != 0 {
+		t.Errorf("%v != 0", b.consecutiveErrors)
+	}
+	if len(b.records) != 0 {
+		t.Errorf("%v != 0", len(b.records))
+	}
+
+	// This next batch should succeed immediately
+	b.addRecordsAndWait(5, 1)
+	if b.consecutiveErrors != 0 {
+		t.Errorf("%v != 0", b.consecutiveErrors)
+	}
+	if len(b.records) != 0 {
+		t.Errorf("%v != 0", len(b.records))
+	}
+}
+
+func TestBatchPartialFailure(t *testing.T) {
+	t.Parallel()
+	b := newBatchProducer(&mockBatchingClient{}, 100, 0, 20)
+	b.maxAttemptsPerRecord = 2
+	b.Start()
+	defer b.Stop()
+
+	b.addRecordsAndWait(19, 0)
+
+	// Add a single record that will fail. partitionKey is (mis)used to specify that the record
+	// should fail.
+	b.Add([]byte("foo"), "fail")
+
+	// First attempt
+	time.Sleep(1 * time.Millisecond)
+	if len(b.records) != 1 {
+		t.Errorf("%v != 1", len(b.records))
+	}
+
+	// Second attempt
+	b.addRecordsAndWait(19, 1)
+	// The failing record should be thrown away at this point
+	if len(b.records) != 0 {
+		t.Errorf("%v != 0", len(b.records))
+	}
+}
+
+func TestBufferSizeStat(t *testing.T) {
+	t.Parallel()
+
+	sr := &statReceiver{}
+
+	b := newBatchProducer(&mockBatchingClient{}, 100, 0, 20)
+	b.statReceiver = sr
+	b.statInterval = 1 * time.Millisecond
+	b.Start()
+	defer b.Stop()
+
+	// Adding 10 will not trigger a batch
+	b.addRecordsAndWait(10, 2)
+
+	if len(sr.stats) == 0 {
+		// More than one might have been sent, which is fine. We just need at least one.
+		t.Fatalf("%v == 0", len(sr.stats))
+	}
+
+	lastStat := sr.stats[len(sr.stats)-1]
+	if lastStat.BufferSize != 10 {
+		t.Errorf("%v != 10", lastStat.BufferSize)
+	}
+
+	// Adding another 10 **will** trigger a batch
+	b.addRecordsAndWait(10, 2)
+
+	if len(sr.stats) < 2 {
+		t.Fatalf("%v < 2", len(sr.stats))
+	}
+
+	lastStat = sr.stats[len(sr.stats)-1]
+	if lastStat.BufferSize != 0 {
+		t.Errorf("%v != 0", lastStat.BufferSize)
+	}
+}
+
+func TestSuccessfulRecordsStat(t *testing.T) {
+	t.Parallel()
+
+	sr := &statReceiver{}
+	b := newBatchProducer(&mockBatchingClient{}, 100, 0, 20)
+	b.statReceiver = sr
+	b.statInterval = 1 * time.Millisecond
+	// b.logger = stdoutLogger // TEMP TEMP TEMP
+	b.Start()
+	defer b.Stop()
+
+	// Adding 10 will not trigger a batch
+	b.addRecordsAndWait(10, 2)
+
+	if len(sr.stats) == 0 {
+		// More than one might have been sent, which is fine. We just need at least one.
+		t.Fatalf("%v == 0", len(sr.stats))
+	}
+
+	lastStat := sr.stats[len(sr.stats)-1]
+	if lastStat.RecordsSentSuccessfullySinceLastStat != 0 {
+		t.Errorf("%v != 0", lastStat.RecordsSentSuccessfullySinceLastStat)
+	}
+
+	// Adding another 10 **will** trigger a batch
+	b.addRecordsAndWait(10, 2)
+
+	if len(sr.stats) < 2 {
+		t.Fatalf("%v < 2", len(sr.stats))
+	}
+
+	if sr.totalRecordsSentSuccessfully != 20 {
+		t.Errorf("%v != 20", sr.totalRecordsSentSuccessfully)
+	}
+}
+
+func TestSuccessfulRecordsStatWhenSomeRecordsFail(t *testing.T) {
+	t.Parallel()
+
+	sr := &statReceiver{}
+	b := newBatchProducer(&mockBatchingClient{}, 100, 0, 20)
+	b.statReceiver = sr
+	b.statInterval = 1 * time.Millisecond
+	b.maxAttemptsPerRecord = 2
+	b.Start()
+	defer b.Stop()
+
+	b.addRecordsAndWait(19, 0)
+
+	// Add a single record that will fail. partitionKey is (mis)used to specify that the record
+	// should fail.
+	b.Add([]byte("foo"), "fail")
+
+	// Sleep long enough for multiple attempts to be tried
+	time.Sleep(3 * time.Millisecond)
+
+	// Should be 10 because one record failed
+	if sr.totalRecordsSentSuccessfully != 19 {
+		t.Errorf("%v != 19", sr.totalRecordsSentSuccessfully)
+	}
+}
+
+func TestRecordsDroppedStatWhenSomeRecordsFail(t *testing.T) {
+	t.Parallel()
+
+	sr := &statReceiver{}
+	b := newBatchProducer(&mockBatchingClient{}, 100, 0, 20)
+	b.statReceiver = sr
+	b.statInterval = 1 * time.Millisecond
+	b.maxAttemptsPerRecord = 1
+	b.Start()
+	defer b.Stop()
+
+	b.addRecordsAndWait(18, 0)
+
+	// Add two records that will fail. partitionKey is (mis)used to specify that the record
+	// should fail.
+	b.Add([]byte("foo"), "fail")
+	b.Add([]byte("foo"), "fail")
+
+	// Sleep long enough for an attempt to be tried and the stat to be recieved
+	time.Sleep(5 * time.Millisecond)
+
+	if sr.totalRecordsDroppedSinceLastStat != 2 {
+		t.Errorf("%v != 2", sr.totalRecordsDroppedSinceLastStat)
+	}
+}
+
+func TestSuccessfulRecordsStatWhenKinesisReturnsError(t *testing.T) {
+	t.Parallel()
+
+	sr := &statReceiver{}
+	b := newBatchProducer(&mockBatchingClient{shouldErr: true}, 100, 0, 20)
+	b.statReceiver = sr
+	b.statInterval = 1 * time.Millisecond
+	b.Start()
+	defer b.Stop()
+
+	// Adding 20 **will** trigger a batch
+	b.addRecordsAndWait(20, 2)
+
+	if len(sr.stats) < 1 {
+		t.Fatalf("%v < 1", len(sr.stats))
+	}
+
+	// Should be 0 because Kinesis is just returning errors
+	if sr.totalRecordsSentSuccessfully != 0 {
+		t.Errorf("%v != 0", sr.totalRecordsSentSuccessfully)
+	}
+}
+
+func TestKinesisErrorsStatWhenKinesisSucceeds(t *testing.T) {
+	t.Parallel()
+
+	sr := &statReceiver{}
+	b := newBatchProducer(&mockBatchingClient{shouldErr: false}, 100, 0, 20)
+	b.statReceiver = sr
+	b.statInterval = 1 * time.Millisecond
+	b.Start()
+	defer b.Stop()
+
+	// Adding 20 **will** trigger a batch
+	b.addRecordsAndWait(20, 2)
+
+	if len(sr.stats) < 1 {
+		t.Fatalf("%v < 1", len(sr.stats))
+	}
+
+	// Should be 0 because Kinesis is succeeding
+	if sr.totalKinesisErrorsSinceLastStat != 0 {
+		t.Errorf("%v != 0", sr.totalKinesisErrorsSinceLastStat)
+	}
+}
+
+func TestKinesisErrorsStatWhenKinesisReturnsError(t *testing.T) {
+	t.Parallel()
+
+	sr := &statReceiver{}
+	b := newBatchProducer(&mockBatchingClient{shouldErr: true}, 100, 0, 20)
+	b.statReceiver = sr
+	b.statInterval = 1 * time.Millisecond
+	b.Start()
+	defer b.Stop()
+
+	b.addRecordsAndWait(20, 1)
+	b.Stop()
+
+	if sr.totalKinesisErrorsSinceLastStat != 2 {
+		t.Errorf("%v != 2", sr.totalKinesisErrorsSinceLastStat)
+	}
+}
+
+type mockBatchingClient struct {
+	calls     int
+	shouldErr bool
+	numToFail int
+}
+
+func (s *mockBatchingClient) PutRecords(args *kinesis.RequestArgs) (resp *kinesis.PutRecordsResp, err error) {
+	s.calls++
+
+	if s.shouldErr {
+		return nil, errors.New("Oh Noes!")
+	}
+
+	res := kinesis.PutRecordsResp{Records: make([]kinesis.PutRecordsRespRecord, len(args.Records))}
+
+	for i, record := range args.Records {
+		if record.PartitionKey == "fail" {
+			res.FailedRecordCount++
+			res.Records[i] = kinesis.PutRecordsRespRecord{ErrorCode: "foo", ErrorMessage: "bar"}
+		} else {
+			res.Records[i] = kinesis.PutRecordsRespRecord{SequenceNumber: "001", ShardId: "001"}
+		}
+	}
+
+	return &res, nil
+}
+
+func newBatchProducer(client *mockBatchingClient, bufferSize int, flushInterval time.Duration, batchSize int) *batchProducer {
+	batchProducer := batchProducer{
+		client:               client,
+		streamName:           "foo",
+		flushInterval:        flushInterval,
+		batchSize:            batchSize,
+		maxAttemptsPerRecord: 2,
+		logger:               discardLogger,
+		currentStat:          new(BatchStat),
+		records:              make(chan batchRecord, bufferSize),
+		stop:                 make(chan interface{}),
+	}
+
+	return &batchProducer
+}
+
+// There are some cases wherein immediately after adding the records we want to sleep for some
+// amount of time in order to allow for the batchProducer’s goroutine to do stuff.
+// A possible alternative approach might be to run with multiple CPUs... but that would probably
+// still require waiting for at least some small amount of time. And in fact it would be way
+// less deterministic and less predictable.
+func (b *batchProducer) addRecordsAndWait(numRecords int, millisToWait int) {
+	data := []byte("The cheese is old and moldy, where is the bathroom?")
+	partitionKey := "foo"
+	for i := 0; i < numRecords; i++ {
+		err := b.Add(data, partitionKey)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	if millisToWait > 0 {
+		time.Sleep(time.Duration(millisToWait) * time.Millisecond)
+	}
+}
+
+type statReceiver struct {
+	stats                            []BatchStat
+	totalKinesisErrorsSinceLastStat  int
+	totalRecordsSentSuccessfully     int
+	totalRecordsDroppedSinceLastStat int
+}
+
+func (s *statReceiver) Receive(bs BatchStat) {
+	s.stats = append(s.stats, bs)
+	s.totalKinesisErrorsSinceLastStat += bs.KinesisErrorsSinceLastStat
+	s.totalRecordsSentSuccessfully += bs.RecordsSentSuccessfullySinceLastStat
+	s.totalRecordsDroppedSinceLastStat += bs.RecordsDroppedSinceLastStat
+}

--- a/batchproducer/batchproducer_test.go
+++ b/batchproducer/batchproducer_test.go
@@ -455,7 +455,7 @@ func newProducer(client *mockBatchingClient, bufferSize int, flushInterval time.
 		batchSize:            batchSize,
 		maxAttemptsPerRecord: 2,
 		logger:               discardLogger,
-		currentStat:          new(StatsFrame),
+		currentStat:          new(StatsBatch),
 		records:              make(chan batchRecord, bufferSize),
 		stop:                 make(chan interface{}),
 	}
@@ -484,13 +484,13 @@ func (b *batchProducer) addRecordsAndWait(numRecords int, millisToWait int) {
 }
 
 type statReceiver struct {
-	stats                            []StatsFrame
+	stats                            []StatsBatch
 	totalKinesisErrorsSinceLastStat  int
 	totalRecordsSentSuccessfully     int
 	totalRecordsDroppedSinceLastStat int
 }
 
-func (s *statReceiver) Receive(sf StatsFrame) {
+func (s *statReceiver) Receive(sf StatsBatch) {
 	s.stats = append(s.stats, sf)
 	s.totalKinesisErrorsSinceLastStat += sf.KinesisErrorsSinceLastStat
 	s.totalRecordsSentSuccessfully += sf.RecordsSentSuccessfullySinceLastStat

--- a/batchproducer/batchproducer_test.go
+++ b/batchproducer/batchproducer_test.go
@@ -19,7 +19,7 @@ var (
 
 func TestNewBatchProducerWithGoodValues(t *testing.T) {
 	t.Parallel()
-	b, err := NewBatchProducer(&mockBatchingClient{}, "foo", 10, 0, 10, discardLogger)
+	b, err := New(&mockBatchingClient{}, "foo", 10, 0, 10, discardLogger)
 	if b == nil {
 		t.Error("b == nil")
 	}
@@ -30,7 +30,7 @@ func TestNewBatchProducerWithGoodValues(t *testing.T) {
 
 func TestNewBatchProducerWithBadBatchSize(t *testing.T) {
 	t.Parallel()
-	b, err := NewBatchProducer(&mockBatchingClient{}, "foo", 10000, 0, 1000, discardLogger)
+	b, err := New(&mockBatchingClient{}, "foo", 10000, 0, 1000, discardLogger)
 	if b != nil {
 		t.Errorf("%q != nil", b)
 	}
@@ -44,7 +44,7 @@ func TestNewBatchProducerWithBadBatchSize(t *testing.T) {
 
 func TestNewBatchProducerWithBadValues(t *testing.T) {
 	t.Parallel()
-	b, err := NewBatchProducer(&mockBatchingClient{}, "foo", 10, 0, 500, discardLogger)
+	b, err := New(&mockBatchingClient{}, "foo", 10, 0, 500, discardLogger)
 	if b != nil {
 		t.Errorf("%q != nil", b)
 	}
@@ -58,7 +58,7 @@ func TestNewBatchProducerWithBadValues(t *testing.T) {
 
 func TestAddRecordWhenStarted(t *testing.T) {
 	t.Parallel()
-	b, err := NewBatchProducer(&mockBatchingClient{}, "foo", 100, 0, 10, discardLogger)
+	b, err := New(&mockBatchingClient{}, "foo", 100, 0, 10, discardLogger)
 	if err != nil {
 		t.Fatalf("%v != nil", err)
 	}
@@ -74,7 +74,7 @@ func TestAddRecordWhenStarted(t *testing.T) {
 
 func TestAddRecordWhenStopped(t *testing.T) {
 	t.Parallel()
-	b, err := NewBatchProducer(&mockBatchingClient{}, "foo", 100, 0, 10, discardLogger)
+	b, err := New(&mockBatchingClient{}, "foo", 100, 0, 10, discardLogger)
 	if err != nil {
 		t.Fatalf("%v != nil", err)
 	}
@@ -88,7 +88,7 @@ func TestAddRecordWhenStopped(t *testing.T) {
 func TestFlushInterval(t *testing.T) {
 	t.Parallel()
 	c := &mockBatchingClient{}
-	b := newBatchProducer(c, 100, 2*time.Millisecond, 10)
+	b := newProducer(c, 100, 2*time.Millisecond, 10)
 	b.Start()
 	defer b.Stop()
 
@@ -121,7 +121,7 @@ func TestFlushInterval(t *testing.T) {
 func TestBatchSize(t *testing.T) {
 	t.Parallel()
 	c := &mockBatchingClient{}
-	b := newBatchProducer(c, 100, 0, 5)
+	b := newProducer(c, 100, 0, 5)
 	b.Start()
 	defer b.Stop()
 
@@ -161,7 +161,7 @@ func TestBatchSize(t *testing.T) {
 func TestBatchError(t *testing.T) {
 	t.Parallel()
 	c := &mockBatchingClient{shouldErr: true}
-	b := newBatchProducer(c, 100, 0, 5)
+	b := newProducer(c, 100, 0, 5)
 	b.Start()
 	defer b.Stop()
 
@@ -206,7 +206,7 @@ func TestBatchError(t *testing.T) {
 
 func TestBatchPartialFailure(t *testing.T) {
 	t.Parallel()
-	b := newBatchProducer(&mockBatchingClient{}, 100, 0, 20)
+	b := newProducer(&mockBatchingClient{}, 100, 0, 20)
 	b.maxAttemptsPerRecord = 2
 	b.Start()
 	defer b.Stop()
@@ -236,7 +236,7 @@ func TestBufferSizeStat(t *testing.T) {
 
 	sr := &statReceiver{}
 
-	b := newBatchProducer(&mockBatchingClient{}, 100, 0, 20)
+	b := newProducer(&mockBatchingClient{}, 100, 0, 20)
 	b.statReceiver = sr
 	b.statInterval = 1 * time.Millisecond
 	b.Start()
@@ -272,7 +272,7 @@ func TestSuccessfulRecordsStat(t *testing.T) {
 	t.Parallel()
 
 	sr := &statReceiver{}
-	b := newBatchProducer(&mockBatchingClient{}, 100, 0, 20)
+	b := newProducer(&mockBatchingClient{}, 100, 0, 20)
 	b.statReceiver = sr
 	b.statInterval = 1 * time.Millisecond
 	// b.logger = stdoutLogger // TEMP TEMP TEMP
@@ -308,7 +308,7 @@ func TestSuccessfulRecordsStatWhenSomeRecordsFail(t *testing.T) {
 	t.Parallel()
 
 	sr := &statReceiver{}
-	b := newBatchProducer(&mockBatchingClient{}, 100, 0, 20)
+	b := newProducer(&mockBatchingClient{}, 100, 0, 20)
 	b.statReceiver = sr
 	b.statInterval = 1 * time.Millisecond
 	b.maxAttemptsPerRecord = 2
@@ -334,7 +334,7 @@ func TestRecordsDroppedStatWhenSomeRecordsFail(t *testing.T) {
 	t.Parallel()
 
 	sr := &statReceiver{}
-	b := newBatchProducer(&mockBatchingClient{}, 100, 0, 20)
+	b := newProducer(&mockBatchingClient{}, 100, 0, 20)
 	b.statReceiver = sr
 	b.statInterval = 1 * time.Millisecond
 	b.maxAttemptsPerRecord = 1
@@ -360,7 +360,7 @@ func TestSuccessfulRecordsStatWhenKinesisReturnsError(t *testing.T) {
 	t.Parallel()
 
 	sr := &statReceiver{}
-	b := newBatchProducer(&mockBatchingClient{shouldErr: true}, 100, 0, 20)
+	b := newProducer(&mockBatchingClient{shouldErr: true}, 100, 0, 20)
 	b.statReceiver = sr
 	b.statInterval = 1 * time.Millisecond
 	b.Start()
@@ -383,7 +383,7 @@ func TestKinesisErrorsStatWhenKinesisSucceeds(t *testing.T) {
 	t.Parallel()
 
 	sr := &statReceiver{}
-	b := newBatchProducer(&mockBatchingClient{shouldErr: false}, 100, 0, 20)
+	b := newProducer(&mockBatchingClient{shouldErr: false}, 100, 0, 20)
 	b.statReceiver = sr
 	b.statInterval = 1 * time.Millisecond
 	b.Start()
@@ -406,7 +406,7 @@ func TestKinesisErrorsStatWhenKinesisReturnsError(t *testing.T) {
 	t.Parallel()
 
 	sr := &statReceiver{}
-	b := newBatchProducer(&mockBatchingClient{shouldErr: true}, 100, 0, 20)
+	b := newProducer(&mockBatchingClient{shouldErr: true}, 100, 0, 20)
 	b.statReceiver = sr
 	b.statInterval = 1 * time.Millisecond
 	b.Start()
@@ -447,7 +447,7 @@ func (s *mockBatchingClient) PutRecords(args *kinesis.RequestArgs) (resp *kinesi
 	return &res, nil
 }
 
-func newBatchProducer(client *mockBatchingClient, bufferSize int, flushInterval time.Duration, batchSize int) *batchProducer {
+func newProducer(client *mockBatchingClient, bufferSize int, flushInterval time.Duration, batchSize int) *batchProducer {
 	batchProducer := batchProducer{
 		client:               client,
 		streamName:           "foo",


### PR DESCRIPTION
We need this for `apicard`, and it seemed like it belonged in this library rather than in application code.

The batch producer:
- Has a single goroutine running in the background
- Uses a channel for buffering and backpressure
- Flushes batches either when a specified batch size
  is in the buffer or when an optional specified
  interval occurs
- Accepts a StatReceiver and will regularly send
  stats to it
- Will retry when HTTP errors occur or are received
- Will retry individual records that fail

The retry behavior in particular is important because Kinesis sometimes returns 500 responses to valid requests, and this is [considered normal by AWS](https://forums.aws.amazon.com/thread.jspa?messageID=531831).

For more details see the godoc comments.

Refs [#2376](https://timehop.clubhousehq.com/project/1/story/2376)

@bdotdub :eyes: please
